### PR TITLE
Specify namespace in kubectl command

### DIFF
--- a/helm-import.sh
+++ b/helm-import.sh
@@ -30,11 +30,11 @@ shift 2
 echo "Adding annotations to all resources found by running template command ..."
 echo ${HELM_BIN} template "${release_name}" "${chart}" ${@}
 echo " "
-${HELM_BIN} template "${release_name}" "${chart}" ${@} | kubectl annotate -f- "meta.helm.sh/release-name=${release_name}" "meta.helm.sh/release-namespace=${HELM_NAMESPACE}" --overwrite || true
+${HELM_BIN} template "${release_name}" "${chart}" ${@} | kubectl -n ${HELM_NAMESPACE} annotate -f- "meta.helm.sh/release-name=${release_name}" "meta.helm.sh/release-namespace=${HELM_NAMESPACE}" --overwrite || true
 echo " "
 
 echo "Adding labels to all resources found by running template command ..."
 echo ${HELM_BIN} template "${release_name}" "${chart}" ${@}
 echo " "
-${HELM_BIN} template "${release_name}" "${chart}" ${@} | kubectl label -f- "app.kubernetes.io/managed-by=Helm" --overwrite || true
+${HELM_BIN} template "${release_name}" "${chart}" ${@} | kubectl -n ${HELM_NAMESPACE} label -f- "app.kubernetes.io/managed-by=Helm" --overwrite || true
 echo " "

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: import
-version: 1.0.0
+version: 1.0.1
 usage: helm import RELEASE_NAME CHART [args ...]
 description: A Helm plugin to import existing Kubernetes resources so they can be managed by a Helm chart.
 command: $HELM_PLUGIN_DIR/helm-import.sh


### PR DESCRIPTION
This PR adds namespace option in kubectl command. Without it the plugin fails to annotate and label resources. Not all charts templates specify the namespace, its always added by helm itself.